### PR TITLE
Make __title__ optional

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -64,12 +64,18 @@ pkutils is intended to be used directly as a Python library.
 
     __version__ = '0.5.4'
 
-    __title__ = 'my_package'
     __author__ = 'Reuben Cummings'
     __description__ = 'My super awesome great package'
     __email__ = 'reubano@gmail.com'
     __license__ = 'MIT'
     __copyright__ = 'Copyright 2015 Reuben Cummings'
+
+You can ``__title__`` explicitly in your Python file.  If you leave
+``__title__`` unset, pkutils will use:
+
+* The parent directory for paths ending in ``__init__.py``.
+* The filename before the extention for other paths
+  (e.g. ``my_package`` for ``my_package.py``).
 
 ``setup.py``
 

--- a/pkutils.py
+++ b/pkutils.py
@@ -235,19 +235,20 @@ def parse_module(filename, encoding='utf-8'):
         (obj): An object whose attributes are accessible in a dict like manner.
 
     Examples:
+        >>> import os
         >>> from tempfile import NamedTemporaryFile
         >>>
         >>> text = (
         ...     "from os import path as p\\n__version__ = '0.12.4'\\n"
-        ...     "__title__ = 'pkutils'\\n__author__ = 'Reuben Cummings'\\n"
+        ...     "__author__ = 'Reuben Cummings'\\n"
         ...     "__email__ = 'reubano@gmail.com'\\n__license__ = 'MIT'\\n")
         >>>
-        >>> with NamedTemporaryFile() as f:
+        >>> with NamedTemporaryFile(suffix='.py') as f:
         ...     bool(f.write(text.encode('utf-8')) or True)
         ...     bool(f.seek(0) or True)
         ...     module = parse_module(f.name)
         ...     module.__version__ == '0.12.4'
-        ...     module.__title__ == module.get('__title__') == 'pkutils'
+        ...     module.__title__ == os.path.splitext(os.path.basename(f.name))[0]
         ...     module.__email__ == module['__email__'] == 'reubano@gmail.com'
         ...     module.missing == module.get('missing') == None
         True

--- a/pkutils.py
+++ b/pkutils.py
@@ -36,7 +36,6 @@ import semver
 
 __version__ = '1.0.0'
 
-__title__ = 'pkutils'
 __author__ = 'Reuben Cummings'
 __description__ = 'Python packaging utility library'
 __email__ = 'reubano@gmail.com'
@@ -258,8 +257,13 @@ def parse_module(filename, encoding='utf-8'):
         True
         True
     """
+    attrs = {}
+    if filename == '__init__.py':
+        attrs['__title__'] = p.basename(p.dirname(filename))
+    else:
+        attrs['__title__'] = p.splitext(p.basename(filename))[0]
     with open(filename, encoding=encoding) as f:
-        attrs = dict(_get_attrs(f))
+        attrs.update(_get_attrs(f))
 
     return Dictlike(attrs)
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 import sys
 
 from io import open
+import os.path
 
 try:
     from setuptools import setup
@@ -25,6 +26,7 @@ def read(filename):
 
 
 def parse_module(filename):
+    yield ('__title__', os.path.splitext(filename)[0])
     with open(filename, encoding='utf-8') as f:
         for line in f:
             if line.startswith('__'):


### PR DESCRIPTION
In many cases, the registered PyPI name will be the same as package/module name, and we will usually be able to construct that from the passed path.  This commit fills in the path-based value as a default, so users who do set `__title__` explicitly will be able to clobber that default with their custom value.